### PR TITLE
Saner binary IO format for converter.py

### DIFF
--- a/accelerate-tensorflow-lite/converter.py
+++ b/accelerate-tensorflow-lite/converter.py
@@ -22,17 +22,17 @@ def parse_representative_data_file(file_path):
             yield dataset
 
 def read_dataset(f):
-    return read_list(f, read_array)
+    return [arr for tup in read_list(f, read_array, lazy=True) for arr in tup]
 
 def read_array(f):
     num_elems = read_word64le(f)
-    return read_list(f, lambda f: read_array_data(num_elems, f))
+    return read_list(f, lambda f: read_array_data(num_elems, f), lazy=True)
 
 def read_array_data(num_elems, f):
     (bytes_per_elem, str_format, numpy_dtype) = read_datatype(f)
     data = bytearray(num_elems * bytes_per_elem)
     f.readinto(data)
-    return np.array(struct.unpack("<" + str_format * size, data), dtype=numpy_dtype)
+    return np.array(struct.unpack("<" + str_format * num_elems, data), dtype=numpy_dtype)
 
 def read_datatype(f):
     # NOTE: Must match encoding used by 'tagOfType'

--- a/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
+++ b/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
@@ -37,7 +37,6 @@ import Control.Exception
 import Data.ByteString                                              ( ByteString )
 import Data.ByteString.Builder                                      ( Builder )
 import Data.Functor.Identity
-import Data.List
 import Data.ProtoLens
 import Formatting
 import Lens.Family2
@@ -61,9 +60,8 @@ import Paths_accelerate_tensorflow_lite
 compileTfunWith :: Tfun f -> [Args f] -> IO ByteString
 compileTfunWith f xs = do
   let f'  = graph_of_model f
-      xs' = B.word8 (genericLength xs) <> foldMap buildArgs xs
   --
-  tflite <- tflite_model f' xs'
+  tflite <- tflite_model f' (serialiseReprData xs)
   edge   <- edgetpu_compile tflite
   model  <- B.readFile edge
   return model


### PR DESCRIPTION
This is an attempt to clean up the binary IO format used to communicate the "representative input data" from `DAA.TF.Lite.Compile.hs` to `converter.py`. This also:
- shortens the serialisation as well as the deserialisation code
- changes length fields to allow more than 255 dimensions, more than 255 samples, and more than 255 model arguments

@dpvanbalen Could you test that this still does the right thing?